### PR TITLE
fix(#12): Consumers are not cleaned after stopping a queue

### DIFF
--- a/src/npqueue_partition_srv.erl
+++ b/src/npqueue_partition_srv.erl
@@ -66,6 +66,7 @@ stop(SrvPid) when is_pid(SrvPid) ->
 %%% INIT/TERMINATE EXPORTS
 %%%-----------------------------------------------------------------------------
 init([QueueName, PartitionNum, ConsumerCount, ConsumerFun]) ->
+    process_flag(trap_exit, true),
     Consumers = init_consumers(QueueName, ConsumerCount, ConsumerFun),
     {ok, #st{
         queue_name = QueueName,

--- a/test/npqueue_SUITE.erl
+++ b/test/npqueue_SUITE.erl
@@ -27,7 +27,8 @@ all() ->
         throttling_updates,
         one_producer,
         one_consumer,
-        performance
+        performance,
+        terminate_stops_consumer
     ].
 
 %%%-----------------------------------------------------------------------------
@@ -282,16 +283,7 @@ one_consumer(_Conf) ->
     lists:foreach(Producer, lists:seq(1, Producers)),
     ct:print("~p producers created...", [Producers]),
     Total = Producers * Items,
-    IsAllConsumed = fun() ->
-        case counters:get(Counter, 1) of
-            Total ->
-                true;
-            Other ->
-                ct:print("Current consumed: ~p of ~p", [Other, Total]),
-                false
-        end
-    end,
-    wait_true(IsAllConsumed),
+    wait_true(is_all_consumed(Counter, Total)),
     0 = npqueue:len(Name),
     Total = npqueue:total_in(Name),
     Total = npqueue:total_out(Name),
@@ -320,16 +312,7 @@ one_producer(_Conf) ->
     spawn(fun() -> producer(Name, 1, Items) end),
     ct:print("1 producer created..."),
     Total = Producers * Items,
-    IsAllConsumed = fun() ->
-        case counters:get(Counter, 1) of
-            Total ->
-                true;
-            Other ->
-                ct:print("Current consumed: ~p of ~p", [Other, Total]),
-                false
-        end
-    end,
-    wait_true(IsAllConsumed),
+    wait_true(is_all_consumed(Counter, Total)),
     0 = npqueue:len(Name),
     Total = npqueue:total_in(Name),
     Total = npqueue:total_out(Name),
@@ -360,16 +343,7 @@ performance(_Conf) ->
     lists:foreach(Producer, lists:seq(1, Producers)),
     ct:print("~p producers created...", [Producers]),
     Total = Producers * Items,
-    IsAllConsumed = fun() ->
-        case counters:get(Counter, 1) of
-            TotalSum ->
-                true;
-            Other ->
-                ct:print("Current num: ~p of ~p", [Other, TotalSum]),
-                false
-        end
-    end,
-    wait_true(IsAllConsumed),
+    wait_true(is_all_consumed(Counter, TotalSum)),
     0 = npqueue:len(Name),
     Total = npqueue:total_in(Name),
     Total = npqueue:total_out(Name),
@@ -380,6 +354,47 @@ performance(_Conf) ->
     ]),
     npqueue:stop(Name),
     ok.
+
+terminate_stops_consumer() ->
+    [{userdata, [{doc, "Tests terminating the consumer along the queue."}]}].
+
+terminate_stops_consumer(_Conf) ->
+    TestPid = self(),
+    Consume = fun(_Item) ->
+        % On consume, just wait until a (exit) message is received
+        TestPid ! consumer_started,
+        receive
+            M -> self() ! M
+        end,
+        TestPid ! {consumer_finished, M}
+    end,
+    Name = test_queue,
+    {ok, _QueuePid} = npqueue:start_link(Name, 1, 1, Consume),
+    producer(Name, item, 1),
+    receive
+        consumer_started -> ok
+    end,
+    npqueue:stop(Name),
+    receive
+        {consumer_finished, _M} -> ok
+    after 2000 ->
+        throw(consumer_timeout)
+    end,
+    ok.
+
+%%%-----------------------------------------------------------------------------
+%%% INTERNAL FUNCTIONS
+%%%-----------------------------------------------------------------------------
+is_all_consumed(Counter, Total) ->
+    fun() ->
+        case counters:get(Counter, 1) of
+            Total ->
+                true;
+            Other ->
+                ct:print("Current num: ~p of ~p", [Other, Total]),
+                false
+        end
+    end.
 
 producer(_Name, _N, 0) ->
     ok;
@@ -392,7 +407,7 @@ wait_true(Fun) ->
         true ->
             ok;
         false ->
-            timer:sleep(1000),
+            timer:sleep(100),
             wait_true(Fun)
     end.
 


### PR DESCRIPTION
All the consumer processes remained alive after calling stop because the terminate/2 function of npqueue_partition_srv was not getting called.

A similar thing happens in npqueue_srv, I will open another PR for that.