### PR TITLE
tests(#16): Take the tests coverage to 100%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
         include:
           - image: erlang:23
           - image: erlang:24
+          - image: erlang:25
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
@@ -51,7 +52,7 @@ jobs:
 
       # Cover reports
       - name: Create Cover Reports
-        run: rebar3 cover
+        run: rebar3 cover -m 100
 
       - name: Publish Test Report
         uses: nomasystems/action-junit-report@v2

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,8 @@
         {ct, "--spec test/conf/ci_test.spec --cover --readable true"}
     ]},
     {test, [
-        {ct, "--spec test/conf/test.spec --cover --readable true"}
+        {ct, "--spec test/conf/test.spec --cover --readable true"},
+        {cover, "-m 100"}
     ]}
 ]}.
 

--- a/src/npqueue_conf.erl
+++ b/src/npqueue_conf.erl
@@ -56,10 +56,6 @@ num_partitions(QueueName, NumPartitions) ->
     NewConf = Conf#{?NUM_PARTITIONS_MAP_KEY => NumPartitions},
     persistent_term:put(Key, NewConf).
 
-partition_server(Conf, PartitionNum) when is_map(Conf) ->
-    #{?PARTITION_SERVERS_MAP_KEY := PartitionServers} = Conf,
-    #{PartitionNum := Server} = PartitionServers,
-    Server;
 partition_server(QueueName, PartitionNum) ->
     #{PartitionNum := Server} = partition_servers(QueueName),
     Server.

--- a/src/npqueue_consumer.erl
+++ b/src/npqueue_consumer.erl
@@ -42,8 +42,6 @@ wait_for_consuming(Parent, QueueName, Fun) ->
         {consume, Item} ->
             npqueue_counters:counter_out_add(QueueName),
             consume(Item, QueueName, Fun);
-        {exit, Reason} ->
-            erlang:exit(Reason);
         {exit, Reason, From} ->
             From ! {erlang:self(), exit},
             erlang:exit(Reason)
@@ -66,11 +64,7 @@ do_consume(Item, QueueName, Fun) ->
         Fun(Item)
     catch
         Class:Reason:Stacktrace ->
-            ?LOG_ERROR("Error consuming the queue ~p. Error: ~p:~p. Stacktrace: ~p", [
-                QueueName,
-                Class,
-                Reason,
-                Stacktrace
-            ]),
+            Params = [QueueName, Class, Reason, Stacktrace],
+            ?LOG_ERROR("Error consuming the queue ~p. Error: ~p:~p. Stacktrace: ~p", Params),
             erlang:raise(Class, Reason, Stacktrace)
     end.

--- a/src/npqueue_srv.erl
+++ b/src/npqueue_srv.erl
@@ -24,9 +24,6 @@
 %%% HANDLE MESSAGES EXPORTS
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
-%%% CODE UPDATE EXPORTS
--export([code_change/3]).
-
 %%% MACROS
 -define(SRV_NAME(Name), list_to_atom(atom_to_list(Name) ++ "_queue_srv")).
 
@@ -88,12 +85,6 @@ handle_cast(Req, St) ->
 
 handle_info(_Info, St) ->
     {noreply, St}.
-
-%%%-----------------------------------------------------------------------------
-%%% CODE UPDATE EXPORTS
-%%%-----------------------------------------------------------------------------
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 %%%-----------------------------------------------------------------------------
 %%% INTERNAL FUNCTIONS

--- a/test/npqueue_partition_srv_SUITE.erl
+++ b/test/npqueue_partition_srv_SUITE.erl
@@ -1,0 +1,74 @@
+%%% Copyright 2022 Nomasystems, S.L. http://www.nomasystems.com
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(npqueue_partition_srv_SUITE).
+
+%%% EXTERNAL EXPORTS
+-compile([export_all, nowarn_export_all]).
+
+%%%-----------------------------------------------------------------------------
+%%% SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+all() ->
+    [
+        handle_unmatched_call,
+        handle_unmatched_cast,
+        handle_unmatched_message
+    ].
+
+%%%-----------------------------------------------------------------------------
+%%% INIT SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+init_per_suite(Conf) ->
+    nct_util:setup_suite(Conf).
+
+%%%-----------------------------------------------------------------------------
+%%% END SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+end_per_suite(Conf) ->
+    nct_util:teardown_suite(Conf).
+
+%%%-----------------------------------------------------------------------------
+%%% TEST CASES
+%%%-----------------------------------------------------------------------------
+handle_unmatched_call() ->
+    [{userdata, [{doc, "Tests that the process crashes if called with an unmatched parameter"}]}].
+
+handle_unmatched_call(_Conf) ->
+    {ok, Pid} = npqueue_partition_srv:start_link(handle_call, 1, 1, fun io:format/1),
+    unlink(Pid),
+    catch gen_server:call(Pid, unmatched_call),
+    false = is_process_alive(Pid),
+    ok.
+
+handle_unmatched_cast() ->
+    [{userdata, [{doc, "Tests that the process crashes if cast with an unmatched parameter"}]}].
+
+handle_unmatched_cast(_Conf) ->
+    {ok, Pid} = npqueue_partition_srv:start_link(handle_cast, 1, 1, fun io:format/1),
+    unlink(Pid),
+    Ref = erlang:monitor(process, Pid),
+    ok = gen_server:cast(Pid, unmatched_cast),
+    receive
+        {'DOWN', Ref, _, _, _} -> ok
+    after 1000 -> throw(cast_timeout)
+    end,
+    ok.
+
+handle_unmatched_message() ->
+    [{userdata, [{doc, "Tests that the process skips unmatched messages"}]}].
+
+handle_unmatched_message(_Conf) ->
+    {ok, Pid} = npqueue_partition_srv:start_link(handle_info, 1, 1, fun io:format/1),
+    Pid ! unmatched_message,
+    ok = npqueue_partition_srv:stop(Pid).

--- a/test/npqueue_srv_SUITE.erl
+++ b/test/npqueue_srv_SUITE.erl
@@ -1,0 +1,75 @@
+%%% Copyright 2022 Nomasystems, S.L. http://www.nomasystems.com
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(npqueue_srv_SUITE).
+
+%%% EXTERNAL EXPORTS
+-compile([export_all, nowarn_export_all]).
+
+%%%-----------------------------------------------------------------------------
+%%% SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+all() ->
+    [
+        handle_unmatched_call,
+        handle_unmatched_cast,
+        handle_unmatched_message
+    ].
+
+%%%-----------------------------------------------------------------------------
+%%% INIT SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+init_per_suite(Conf) ->
+    nct_util:setup_suite(Conf).
+
+%%%-----------------------------------------------------------------------------
+%%% END SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+end_per_suite(Conf) ->
+    nct_util:teardown_suite(Conf).
+
+%%%-----------------------------------------------------------------------------
+%%% TEST CASES
+%%%-----------------------------------------------------------------------------
+handle_unmatched_call() ->
+    [{userdata, [{doc, "Tests that the process crashes if called with an unmatched parameter"}]}].
+
+handle_unmatched_call(_Conf) ->
+    {ok, _Pid} = npqueue:start_link(handle_call, 1, 1, fun io:format/1),
+    QueueSrvPid = whereis(handle_call_queue_srv),
+    catch gen_server:call(QueueSrvPid, unmatched_call),
+    false = is_process_alive(QueueSrvPid),
+    ok.
+
+handle_unmatched_cast() ->
+    [{userdata, [{doc, "Tests that the process crashes if cast with an unmatched parameter"}]}].
+
+handle_unmatched_cast(_Conf) ->
+    {ok, _Pid} = npqueue:start_link(handle_cast, 1, 1, fun io:format/1),
+    QueueSrvPid = whereis(handle_cast_queue_srv),
+    Ref = erlang:monitor(process, QueueSrvPid),
+    ok = gen_server:cast(QueueSrvPid, unmatched_cast),
+    receive
+        {'DOWN', Ref, _, _, _} -> ok
+    after 1000 -> throw(cast_timeout)
+    end,
+    ok.
+
+handle_unmatched_message() ->
+    [{userdata, [{doc, "Tests that the process skips unmatched messages"}]}].
+
+handle_unmatched_message(_Conf) ->
+    {ok, _Pid} = npqueue:start_link(handle_info, 1, 1, fun io:format/1),
+    QueueSrvPid = whereis(handle_info_queue_srv),
+    QueueSrvPid ! unmatched_message,
+    ok = gen_server:stop(QueueSrvPid).


### PR DESCRIPTION
In order to achieve it, I had to delete some code branches that were unreachable.

Also changed some tests to run faster and ensured that they run in Erlang/OTP 25.

Closes #16.